### PR TITLE
BUGFIX: Do not index text nodes

### DIFF
--- a/Classes/Controller/SuggestController.php
+++ b/Classes/Controller/SuggestController.php
@@ -122,6 +122,7 @@ class SuggestController extends ActionController
                     'completion' => [
                         'field' => '__suggestions',
                         'fuzzy' => true,
+                        'size' => 10,
                         'context' => [
                             'parentPath' => $contextNode->getPath(),
                             'workspace' => 'live',

--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -19,15 +19,3 @@
   superTypes:
     'Flowpack.SearchPlugin:SuggestableMixin': true
     'Flowpack.SearchPlugin:AutocompletableMixin': true
-
-'Neos.NodeTypes:TextMixin':
-  superTypes:
-    'Flowpack.SearchPlugin:SuggestableMixin': true
-    'Flowpack.SearchPlugin:AutocompletableMixin': true
-  properties:
-    '__suggestions':
-      search:
-        indexing: "${Flowpack.SearchPlugin.Suggestion.buildConfig(q(node).property('text'), {nodeIdentifier: node.identifier}, 10)}"
-    '__completion':
-      search:
-        indexing: "${q(node).property('text')}"


### PR DESCRIPTION
After fixing the bug with indexing - the index explodes
when using texts for suggestions and autocompletion.