### PR TITLE
Task: Use output correctly

### DIFF
--- a/Classes/EelHelper/SuggestionIndexHelper.php
+++ b/Classes/EelHelper/SuggestionIndexHelper.php
@@ -23,16 +23,17 @@ class SuggestionIndexHelper implements ProtectedContextAwareInterface
 {
 
     /**
-     * @param string $input
-     * @param array $payload
-     * @param int $weight
+     * @param string $input The input to store, this can be a an array of strings or just a string. This field is mandatory.
+     * @param string $output The result is de-duplicated if several documents have the same output, i.e. only one is returned as part of the suggest result.
+     * @param array $payload An arbitrary JSON object, which is simply returned in the suggest option.
+     * @param int $weight A positive integer or a string containing a positive integer, which defines a weight and allows you to rank your suggestions.
      * @return array
      */
-    public function buildConfig($input, array $payload = [], $weight = 1)
+    public function build($input, $output = '', array $payload = [], $weight = 1)
     {
         return [
             'input' => $this->prepareInput($input),
-            'output' => $this->prepareOutput($input),
+            'output' => $this->prepareOutput($output),
             'payload' => json_encode($payload),
             'weight' => $weight
         ];

--- a/Configuration/NodeTypes.Mixins.yaml
+++ b/Configuration/NodeTypes.Mixins.yaml
@@ -16,7 +16,7 @@
             dimensionCombinationHash:
               type: category
               path: '__dimensionCombinationHash'
-        indexing: "${Flowpack.SearchPlugin.Suggestion.buildConfig(q(node).property('title'), {nodeIdentifier: node.identifier}, 20)}"
+        indexing: "${Flowpack.SearchPlugin.Suggestion.buildConfig(q(node).property('title'), q(node).is('[instanceof Neos.Neos:Document]') ? node.identifier : q(node).parents('[instanceof Neos.Neos:Document]').get(0).identifier, {nodeIdentifier: node.identifier}, 20)}"
 
 'Flowpack.SearchPlugin:AutocompletableMixin':
   abstract: true


### PR DESCRIPTION
For suggestions, two hits are deduplicated when they produce the same output. By default it make sense to deduplicate hits by the linked document, so the document identifier is used. This also reduces the index document size a lot.

Also improved documentation and changed the method name as it is not a config that is built.