### PR TITLE
Add Support for inherited dimensions

### DIFF
--- a/Resources/Private/Fusion/SearchPlugin.fusion
+++ b/Resources/Private/Fusion/SearchPlugin.fusion
@@ -33,7 +33,7 @@ prototype(Flowpack.SearchPlugin:Search) < prototype(Neos.Neos:Content) {
 
 prototype(Flowpack.SearchPlugin:Search.Form) < prototype(Neos.Fusion:Template) {
     node = ${site}
-    dimensionCombination = ${Json.stringify(this.node.dimensions)}
+    dimensionCombination = ${Json.stringify(this.node.context.dimensions)}
     templatePath = 'resource://Flowpack.SearchPlugin/Private/Templates/NodeTypes/Search.Form.html'
     inputClassNames = ''
     searchWord = ${request.arguments.search}


### PR DESCRIPTION
Get the dimensions from node.context.dimensions.
This way it works also with inherited dimensions like in this example for "ch": {"country":["ch", "int"],"language":["de"]}